### PR TITLE
ベクタ画像アセットの追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feature/*
 
 env:
   NODE_VERSION: 14

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-types",
-  "version": "2.0.0-feature.0",
+  "version": "1.3.0-feature.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-types",
-  "version": "1.1.1",
+  "version": "2.0.0-feature.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-types",
-  "version": "1.1.1",
+  "version": "2.0.0-feature.0",
   "description": "Interface definition for Akashic Platform Dependent Implementation (PDI) Layer",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -47,6 +47,7 @@
     "@akashic/trigger": "~1.0.0"
   },
   "publishConfig": {
-    "@akashic:registry": "https://registry.npmjs.org/"
+    "@akashic:registry": "https://registry.npmjs.org/",
+    "tag": "feature"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-types",
-  "version": "2.0.0-feature.0",
+  "version": "1.3.0-feature.0",
   "description": "Interface definition for Akashic Platform Dependent Implementation (PDI) Layer",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/asset/vector-image/VectorImageAsset.ts
+++ b/src/asset/vector-image/VectorImageAsset.ts
@@ -1,0 +1,41 @@
+import { Surface } from "../../surface/Surface";
+import { Asset } from "../Asset";
+import { VectorImageAssetHint } from "./VectorImageAssetHint";
+
+/**
+ * ベクタ画像リソースを表すインターフェース。
+ * 本クラスのインスタンスをゲーム開発者が直接生成することはない。
+ * game.jsonによって定義された内容をもとに暗黙的に生成されたインスタンスを、
+ * Scene#assets、またはGame#assetsによって取得して利用する。
+ */
+export interface VectorImageAsset extends Asset {
+	type: "vector-image";
+	hint: VectorImageAssetHint | undefined;
+
+	/**
+	 * サーフェスを生成する。
+	 * ベクタ画像をサポートしない環境においては `null` を返す。
+	 * @param width 作成するサーフェスの幅。
+	 * @param height 作成するサーフェスの高さ。
+	 */
+	createSurface(width: number, height: number): Surface | null;
+
+	/**
+	 * サーフェスを生成する。
+	 * ベクタ画像をサポートしない環境においては `null` を返す。
+	 * @param width 作成するサーフェスの幅。
+	 * @param height 作成するサーフェスの高さ。
+	 * @param sx 元画像の描画矩形範囲のx座標。
+	 * @param sy 元画像の描画矩形範囲のy座標。
+	 * @param sWidth 元画像の描画矩形範囲の幅。
+	 * @param sHeight 元画像の描画矩形範囲の高さ。
+	 */
+	createSurface(
+		width: number,
+		height: number,
+		sx: number,
+		sy: number,
+		sWidth: number,
+		sHeight: number
+	): Surface | null;
+}

--- a/src/asset/vector-image/VectorImageAsset.ts
+++ b/src/asset/vector-image/VectorImageAsset.ts
@@ -10,6 +10,8 @@ import { VectorImageAssetHint } from "./VectorImageAssetHint";
  */
 export interface VectorImageAsset extends Asset {
 	type: "vector-image";
+	width: number;
+	height: number;
 	hint: VectorImageAssetHint | undefined;
 
 	/**

--- a/src/asset/vector-image/VectorImageAssetHint.ts
+++ b/src/asset/vector-image/VectorImageAssetHint.ts
@@ -1,0 +1,6 @@
+/**
+ * VectorImageAssetの設定を表すインターフェース。
+ */
+export interface VectorImageAssetHint {
+	untainted?: boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ export * from "./asset/text/TextAsset";
 export * from "./asset/video/VideoPlayer";
 export * from "./asset/video/VideoSystem";
 export * from "./asset/video/VideoAsset";
+export * from "./asset/vector-image/VectorImageAsset";
+export * from "./asset/vector-image/VectorImageAssetHint";
 export * from "./asset/Asset";
 export * from "./asset/AssetLoadErrorType";
 

--- a/src/platform/ResourceFactory.ts
+++ b/src/platform/ResourceFactory.ts
@@ -48,7 +48,7 @@ export interface ResourceFactory {
 
 	createScriptAsset(id: string, assetPath: string): ScriptAsset;
 
-	createVectorImageAsset(
+	createVectorImageAsset?(
 		id: string,
 		assetPath: string,
 		width: number,

--- a/src/platform/ResourceFactory.ts
+++ b/src/platform/ResourceFactory.ts
@@ -48,7 +48,13 @@ export interface ResourceFactory {
 
 	createScriptAsset(id: string, assetPath: string): ScriptAsset;
 
-	createVectorImageAsset(id: string, assetPath: string, hint: VectorImageAssetHint): VectorImageAsset;
+	createVectorImageAsset(
+		id: string,
+		assetPath: string,
+		width: number,
+		height: number,
+		hint?: VectorImageAssetHint
+	): VectorImageAsset;
 
 	/**
 	 * Surface を作成する。

--- a/src/platform/ResourceFactory.ts
+++ b/src/platform/ResourceFactory.ts
@@ -5,6 +5,8 @@ import { AudioSystem } from "../asset/audio/AudioSystem";
 import { ImageAsset } from "../asset/image/ImageAsset";
 import { ScriptAsset } from "../asset/script/ScriptAsset";
 import { TextAsset } from "../asset/text/TextAsset";
+import { VectorImageAsset } from "../asset/vector-image/VectorImageAsset";
+import { VectorImageAssetHint } from "../asset/vector-image/VectorImageAssetHint";
 import { VideoAsset } from "../asset/video/VideoAsset";
 import { VideoSystem } from "../asset/video/VideoSystem";
 import { FontWeightString } from "../font/FontWeightString";
@@ -45,6 +47,8 @@ export interface ResourceFactory {
 	createAudioPlayer(system: AudioSystem): AudioPlayer;
 
 	createScriptAsset(id: string, assetPath: string): ScriptAsset;
+
+	createVectorImageAsset(id: string, assetPath: string, hint: VectorImageAssetHint): VectorImageAsset;
 
 	/**
 	 * Surface を作成する。

--- a/test/pdi-build-test.ts
+++ b/test/pdi-build-test.ts
@@ -103,6 +103,9 @@ class AbstractResourceFactory implements pdi.ResourceFactory {
 	createScriptAsset(_id: string, _assetPath: string): pdi.ScriptAsset {
 		throw new Error("AbstractResourceFactory#createScriptAsset()");
 	}
+	createVectorImageAsset(_id: string, _assetPath: string, _hint: pdi.VectorImageAssetHint): pdi.VectorImageAsset {
+		throw new Error("AbstractResourceFactory#createVectorImageAsset()");
+	}
 	createSurface(_width: number, _height: number): pdi.Surface {
 		throw new Error("AbstractResourceFactory#createSurface()");
 	}

--- a/test/pdi-build-test.ts
+++ b/test/pdi-build-test.ts
@@ -103,7 +103,13 @@ class AbstractResourceFactory implements pdi.ResourceFactory {
 	createScriptAsset(_id: string, _assetPath: string): pdi.ScriptAsset {
 		throw new Error("AbstractResourceFactory#createScriptAsset()");
 	}
-	createVectorImageAsset(_id: string, _assetPath: string, _hint: pdi.VectorImageAssetHint): pdi.VectorImageAsset {
+	createVectorImageAsset(
+		_id: string,
+		_assetPath: string,
+		_width: number,
+		_height: number,
+		_hint: pdi.VectorImageAssetHint
+	): pdi.VectorImageAsset {
 		throw new Error("AbstractResourceFactory#createVectorImageAsset()");
 	}
 	createSurface(_width: number, _height: number): pdi.Surface {


### PR DESCRIPTION
## このPullRequestが解決する内容
ベクタ画像のサポートのため `vector-image` のアセット種別を追加します。
