### PR TITLE
feat: オーディオアセットのオフセット位置指定再生のサポート

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 1.4.0
+* オーディオアセットのオフセット位置指定再生のサポート
+  * `AudioAsset#offset` を追加
+  * `AudioAsset#play()` に引数を追加
+  * `AudioPlayer#play()` に引数を追加
+  * `ResourceFactory#createAudioAsset()` に引数を追加
+
 ## 1.3.0
 * `VectorImageAsset` の設定を追加
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/pdi-types",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/pdi-types",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/amflow": "~3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-types",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Interface definition for Akashic Platform Dependent Implementation (PDI) Layer",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/asset/audio/AudioAsset.ts
+++ b/src/asset/audio/AudioAsset.ts
@@ -17,13 +17,14 @@ export interface AudioAsset extends Asset {
 	duration: number;
 	loop: boolean;
 	hint: AudioAssetHint;
+	offset: number;
 
 	/**
 	 * @ignore
 	 */
 	_system: AudioSystem;
 
-	play(): AudioPlayer;
+	play(offset?: number, duration?: number): AudioPlayer;
 
 	stop(): void;
 

--- a/src/asset/audio/AudioPlayer.ts
+++ b/src/asset/audio/AudioPlayer.ts
@@ -56,13 +56,16 @@ export interface AudioPlayer {
 	 * @private
 	 */
 	_muted: boolean;
+
 	/**
 	 * `AudioAsset` を再生する。
 	 *
 	 * 再生後、 `this.onPlay` がfireされる。
 	 * @param audio 再生するオーディオアセット
+	 * @param offset 再生するオーディオの開始位置 (ミリ秒)。省略された場合 `0`。
+	 * @param duration 再生するオーディオの長さ (ミリ秒)。省略された場合、対象の `AudioAsset` の再生時間。
 	 */
-	play(audio: AudioAsset): void;
+	play(audio: AudioAsset, offset?: number, duration?: number): void;
 
 	/**
 	 * 再生を停止する。

--- a/src/platform/ResourceFactory.ts
+++ b/src/platform/ResourceFactory.ts
@@ -39,7 +39,8 @@ export interface ResourceFactory {
 		duration: number,
 		system: AudioSystem,
 		loop: boolean,
-		hint: AudioAssetHint
+		hint: AudioAssetHint,
+		offset?: number
 	): AudioAsset;
 
 	createTextAsset(id: string, assetPath: string): TextAsset;


### PR DESCRIPTION
## このPullRequestが解決する内容
オーディオアセットのオフセット位置指定再生をサポートします。
  * `AudioAsset#offset` を追加
  * `AudioAsset#play()` に引数を追加
  * `AudioPlayer#play()` に引数を追加
  * `ResourceFactory#createAudioAsset()` に引数を追加