### PR TITLE
feat: ResourceFactory#_createVectorImageAssetFromString() の引数に assetPath を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.4.0-beta.1
+* `ResourceFactory#_createVectorImageAssetFromString()` の引数に assetPath を追加
+
 ## 1.4.0-beta.0
 * `ResourceFactory#_createVectorImageAssetFromString()` を追加
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/pdi-types",
-  "version": "1.4.0-beta.0",
+  "version": "1.4.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/pdi-types",
-      "version": "1.4.0-beta.0",
+      "version": "1.4.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/amflow": "~3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-types",
-  "version": "1.4.0-beta.0",
+  "version": "1.4.0-beta.1",
   "description": "Interface definition for Akashic Platform Dependent Implementation (PDI) Layer",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/platform/ResourceFactory.ts
+++ b/src/platform/ResourceFactory.ts
@@ -93,5 +93,5 @@ export interface ResourceFactory {
 		fontWeight?: FontWeightString
 	): GlyphFactory;
 
-	 createVectorImageAssetFromString?(id: string, data: string): VectorImageAsset;
+	 createVectorImageAssetFromString?(id: string, assetPath: string, data: string): VectorImageAsset;
 }

--- a/test/pdi-build-test.ts
+++ b/test/pdi-build-test.ts
@@ -122,7 +122,7 @@ class AbstractResourceFactory implements Required<pdi.ResourceFactory> {
 		throw new Error("AbstractResourceFactory#createGlyphFactory()");
 	}
 
-	createVectorImageAssetFromString(_id: string, _data: string): pdi.VectorImageAsset {
+	createVectorImageAssetFromString(_id: string, _assetPath: string, _data: string): pdi.VectorImageAsset {
 		throw new Error("AbstractResourceFactory#_createVectorImageAssetFromString()");
 	}
 }


### PR DESCRIPTION
# このPullRequestが解決する内容
`ResourceFactory#_createVectorImageAssetFromString()` の引数に assetPath を追加します。