### PR TITLE
fix: add exports as an argument to createScriptAsset()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.10.1
+* `ResourceFactory#createScriptAsset()` の引数に exports を追加
+
 ## 1.10.0
 * `BinaryAsset` を追加
 * `ScriptAsset#exports` を追加

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/pdi-types",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/pdi-types",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/amflow": "~3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-types",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Interface definition for Akashic Platform Dependent Implementation (PDI) Layer",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/platform/ResourceFactory.ts
+++ b/src/platform/ResourceFactory.ts
@@ -48,7 +48,7 @@ export interface ResourceFactory {
 
 	createAudioPlayer(system: AudioSystem): AudioPlayer;
 
-	createScriptAsset(id: string, assetPath: string): ScriptAsset;
+	createScriptAsset(id: string, assetPath: string, exports?: string[]): ScriptAsset;
 
 	createVectorImageAsset?(
 		id: string,


### PR DESCRIPTION
# このPullRequestが解決する内容
`ResourceFactory#createScriptAsset()` の第三引数に `exports?: string[]` を追加します。
#56 に入れ忘れた自明な修正のためセルフマージします。