### PR TITLE
chore: add devEngines.packageManager to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,12 @@
   },
   "publishConfig": {
     "@akashic:registry": "https://registry.npmjs.org/"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.11.0",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
This PR adds `devEngines.packageManager` to package.json to enforce npm version.